### PR TITLE
Update AWS CLI to 1.18.18

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -6,7 +6,7 @@ sudo apt-get update
 # python and awscli
 sudo apt-get install -qq -y python-pip libpython-dev
 sudo curl -O https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
-sudo pip install -q awscli==1.16.180 --upgrade # lock version
+sudo pip install -q awscli==1.18.18 --upgrade # lock version
 
 # jq json parser
 sudo apt-get install jq


### PR DESCRIPTION
We need version [1.16.210](https://github.com/aws/aws-cli/blob/develop/CHANGELOG.rst#116210) for STS AssumeRoleWithWebIdentity but might as well just jump to the latest release?

### PR Checklist
- [x] I have tested my build locally
- [x] I have checked for vulnerabilities in this image
